### PR TITLE
Use non-root user in container and update base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
-FROM alpine:3.9
+FROM alpine:3.13
 
 RUN apk add --no-cache curl
+
+USER 1001:1001


### PR DESCRIPTION
## Description
PR specifies a non-privileged user to be used in the service's container. It's a preparation for the introduction of the Pod Security Policy which doesn't allow the usage of root users.

Additionally it updates the base image: alpine 3.9 -> 3.13

## Related PRs
https://github.com/collectai/cluster/pull/375

## Related Jira task
CAI-8892
